### PR TITLE
Replace InputStream.readAllBytes with simple static copy method for Android compatibility

### DIFF
--- a/src/main/java/net/luminis/tls/compat/InputStreamCompat.java
+++ b/src/main/java/net/luminis/tls/compat/InputStreamCompat.java
@@ -1,0 +1,22 @@
+package net.luminis.tls.compat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class InputStreamCompat {
+
+    public static byte[] readAllBytes(InputStream in) throws IOException{
+        byte[] buf = new byte[8192];
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        int bytesRead;
+
+        while((bytesRead = in.read(buf)) != -1) {
+            bout.write(buf, 0, bytesRead);
+        }
+        bout.flush();
+
+        return bout.toByteArray();
+    }
+
+}

--- a/src/main/java/net/luminis/tls/handshake/TlsServerEngineFactory.java
+++ b/src/main/java/net/luminis/tls/handshake/TlsServerEngineFactory.java
@@ -19,6 +19,7 @@
 package net.luminis.tls.handshake;
 
 import net.luminis.tls.TlsConstants;
+import net.luminis.tls.compat.InputStreamCompat;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -57,7 +58,7 @@ public class TlsServerEngineFactory {
     }
 
     private static List<X509Certificate> readCertificates(InputStream file) throws IOException, CertificateException {
-        String fileContent = new String(file.readAllBytes(), Charset.defaultCharset());
+        String fileContent = new String(InputStreamCompat.readAllBytes(file), Charset.defaultCharset());
         String[] chunks = fileContent.split("-----END CERTIFICATE-----\n");
 
         List<X509Certificate> certs = new ArrayList<>();
@@ -78,7 +79,7 @@ public class TlsServerEngineFactory {
     }
 
     private RSAPrivateKey readPrivateKey(InputStream file) throws IOException, InvalidKeySpecException {
-        String key = new String(file.readAllBytes(), Charset.defaultCharset());
+        String key = new String(InputStreamCompat.readAllBytes(file), Charset.defaultCharset());
 
         String privateKeyPEM = key
                 .replace("-----BEGIN PRIVATE KEY-----", "")


### PR DESCRIPTION
Hi,

InputStream.readAllBytes is not available on any device pre-SDK33 (Android 13 - the latest release) device. This method is also not supported by [desguaring](https://developer.android.com/studio/write/java11-default-support-table). 

When I replaced readAllBytes with a simple copy method (using ByteArrayOutputStream), use desugaring, and set the platform on Kwik to Android, I am able to run the echo test (including server and client) on an Android device.

All gradle tests passed after this minor change. This change makes it possible to use the library on Android.

