### PR TITLE
add tls-exporter api as par RFC 8446, Section 7.5

### DIFF
--- a/src/main/java/tech/kwik/agent15/engine/TlsEngine.java
+++ b/src/main/java/tech/kwik/agent15/engine/TlsEngine.java
@@ -19,4 +19,10 @@
 package tech.kwik.agent15.engine;
 
 public interface TlsEngine extends MessageProcessor, TrafficSecrets {
+
+    /**
+     * Derives keying material using the TLS 1.3 exporter function (RFC 8446, Section 7.5).
+     */
+    byte[] exportKeyingMaterial(String label, byte[] context, int length);
+
 }

--- a/src/main/java/tech/kwik/agent15/engine/impl/TlsClientEngineImpl.java
+++ b/src/main/java/tech/kwik/agent15/engine/impl/TlsClientEngineImpl.java
@@ -450,6 +450,7 @@ public class TlsClientEngineImpl extends TlsEngineImpl implements TlsClientEngin
 
         transcriptHash.recordClient(clientFinished);
         state.computeApplicationSecrets();
+        state.computeExporterSecret();
         state.computeResumptionMasterSecret();
         status = Status.Connected;
         statusHandler.handshakeFinished();

--- a/src/main/java/tech/kwik/agent15/engine/impl/TlsEngineImpl.java
+++ b/src/main/java/tech/kwik/agent15/engine/impl/TlsEngineImpl.java
@@ -308,6 +308,16 @@ public abstract class TlsEngineImpl implements TlsEngine {
         }
     }
 
+    @Override
+    public byte[] exportKeyingMaterial(String label, byte[] context, int length) {
+        if (state != null) {
+            return state.exportKeyingMaterial(label, context, length);
+        }
+        else {
+            throw new IllegalStateException("Exporter secret not yet available; handshake not completed yet.");
+        }
+    }
+
     protected boolean recognizedExtension(Extension extension) {
         return ! (extension instanceof UnknownExtension);
     }

--- a/src/main/java/tech/kwik/agent15/engine/impl/TlsServerEngineImpl.java
+++ b/src/main/java/tech/kwik/agent15/engine/impl/TlsServerEngineImpl.java
@@ -279,6 +279,7 @@ public class TlsServerEngineImpl extends TlsEngineImpl implements TlsServerEngin
         serverMessageSender.send(finished);
         transcriptHash.recordServer(finished);
         state.computeApplicationSecrets();
+        state.computeExporterSecret();
 
         status = Status.WaitFinished;
     }

--- a/src/main/java/tech/kwik/agent15/engine/impl/TlsState.java
+++ b/src/main/java/tech/kwik/agent15/engine/impl/TlsState.java
@@ -68,6 +68,7 @@ public class TlsState implements BinderCalculator {
     private final TranscriptHash transcriptHash;
     private byte[] sharedSecret;
     private byte[] masterSecret;
+    private byte[] exporterSecret;
 
     public TlsState(TranscriptHash transcriptHash, byte[] psk, int keyLength, int hashLength) {
         this.psk = psk;
@@ -221,6 +222,40 @@ public class TlsState implements BinderCalculator {
         byte[] clientFinishedHash = transcriptHash.getClientHash(TlsConstants.HandshakeType.finished);
 
         resumptionMasterSecret = hkdfExpandLabel(masterSecret, "res master", clientFinishedHash, hashLength);
+    }
+
+    /**
+     * Computes the TLS 1.3 exporter secret (RFC 8446, Section 7.5).
+     * The exporter secret is derived from the server's application traffic secret:
+     *   exporter_secret = Derive-Secret(server_application_traffic_secret, "exporter", "")
+     * This ensures both client and server can derive the same key material.
+     * Must be called after computeApplicationSecrets().
+     */
+    public void computeExporterSecret() {
+        // Derive-Secret(Secret, Label, Messages) = HKDF-Expand-Label(Secret, Label, Transcript-Hash(Messages), Hash.length)
+        // For the exporter, Messages is "" (empty), so Transcript-Hash("") = emptyHash
+        if (serverApplicationTrafficSecret == null) {
+            throw new IllegalStateException("Server application traffic secret not available");
+        }
+        exporterSecret = hkdfExpandLabel(serverApplicationTrafficSecret, "exporter", emptyHash, hashLength);
+    }
+
+    /**
+     * Implements the TLS 1.3 exporter function (RFC 8446, Section 7.5):
+     *   TLS-Exporter(label, context_value, key_length) =
+     *       HKDF-Expand-Label(exporter_secret, label, context_value, key_length)
+     *
+     * @param label   the exporter label
+     * @param context the context value
+     * @param length  the desired output length in bytes
+     * @return the derived keying material
+     * @throws IllegalStateException if the exporter secret has not been computed yet
+     */
+    public byte[] exportKeyingMaterial(String label, byte[] context, int length) {
+        if (exporterSecret == null) {
+            throw new IllegalStateException("Exporter secret not available; handshake may not be complete yet");
+        }
+        return hkdfExpandLabel(exporterSecret, label, context, (short) length);
     }
 
     // https://tools.ietf.org/html/rfc8446#section-4.6.1


### PR DESCRIPTION
When quic was used with protocols (such as XMPP) using SASL, they may provide a `*-PLUS` mechanism with channel binding to mitigate MIMT attack. This commit introduces the tls-exporter api required by channel binding.