### PR TITLE
Wire up the RFC 10024 hybrid groups

### DIFF
--- a/src/main/java/tech/kwik/agent15/engine/impl/KeyExchangeFactoryImpl.java
+++ b/src/main/java/tech/kwik/agent15/engine/impl/KeyExchangeFactoryImpl.java
@@ -21,6 +21,8 @@ package tech.kwik.agent15.engine.impl;
 import tech.kwik.agent15.TlsConstants;
 import tech.kwik.agent15.engine.KeyExchange;
 import tech.kwik.agent15.engine.KeyExchangeFactory;
+import tech.kwik.agent15.engine.MLKEM768KeyExchange;
+import tech.kwik.agent15.engine.MLKEM1024KeyExchange;
 
 import static tech.kwik.agent15.TlsConstants.NamedGroup.*;
 
@@ -34,10 +36,27 @@ public class KeyExchangeFactoryImpl implements KeyExchangeFactory {
         if (group == secp256r1 || group == secp384r1 || group == secp521r1) {
             return new ECKeyExchange(group);
         }
+        if (group == X25519MLKEM768) {
+            return new X25519MLKEM768KeyExchange();
+        }
+        if (group == SecP256r1MLKEM768) {
+            return new SecP256r1MLKEM768KeyExchange();
+        }
+        if (group == SecP384r1MLKEM1024) {
+            return new SecP384r1MLKEM1024KeyExchange();
+        }
         return null;
     }
 
     @Override
     public void init() {
+        // MLKEM768KeyExchange/MLKEM1024KeyExchange each derive and cache a
+        // DER prefix from a throwaway key pair the first time the class is
+        // touched (measured ~260-500us). Touching them here, explicitly,
+        // means that cost lands during this warm-up call rather than on
+        // whichever handshake happens to be first to need one of the
+        // hybrid groups.
+        new MLKEM768KeyExchange();
+        new MLKEM1024KeyExchange();
     }
 }

--- a/src/main/java/tech/kwik/agent15/engine/impl/SecP256r1MLKEM768KeyExchange.java
+++ b/src/main/java/tech/kwik/agent15/engine/impl/SecP256r1MLKEM768KeyExchange.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2026 Peter Doornbosch, Chris Burdess
+ *
+ * This file is part of Agent15, an implementation of TLS 1.3 in Java.
+ *
+ * Agent15 is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Agent15 is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package tech.kwik.agent15.engine.impl;
+
+import tech.kwik.agent15.engine.HybridKeyExchange;
+import tech.kwik.agent15.engine.MLKEM768KeyExchange;
+
+import static tech.kwik.agent15.TlsConstants.NamedGroup.secp256r1;
+
+/**
+ * The SecP256r1MLKEM768 hybrid group (RFC 10024): classical (EC) component
+ * first in the client/server key shares and the secret combiner.
+ */
+public class SecP256r1MLKEM768KeyExchange extends HybridKeyExchange {
+
+    public SecP256r1MLKEM768KeyExchange() {
+        super("SecP256r1MLKEM768", new ECKeyExchange(secp256r1), 65,
+                new MLKEM768KeyExchange(), MLKEM768KeyExchange.ENCAPSULATION_KEY_LENGTH,
+                MLKEM768KeyExchange.CIPHERTEXT_LENGTH, false);
+    }
+}

--- a/src/main/java/tech/kwik/agent15/engine/impl/SecP256r1MLKEM768KeyExchange.java
+++ b/src/main/java/tech/kwik/agent15/engine/impl/SecP256r1MLKEM768KeyExchange.java
@@ -29,8 +29,13 @@ import static tech.kwik.agent15.TlsConstants.NamedGroup.secp256r1;
  */
 public class SecP256r1MLKEM768KeyExchange extends HybridKeyExchange {
 
+    // RFC 8446 section 4.2.8.2 -- matches ECKeyExchange's own (private)
+    // CURVE_KEY_LENGTHS entry for secp256r1 (uncompressed point: 1 +
+    // 2 * 32-byte coordinates).
+    public static final int SECP256R1_SHARE_LENGTH = 65;
+
     public SecP256r1MLKEM768KeyExchange() {
-        super("SecP256r1MLKEM768", new ECKeyExchange(secp256r1), 65,
+        super("SecP256r1MLKEM768", new ECKeyExchange(secp256r1), SECP256R1_SHARE_LENGTH,
                 new MLKEM768KeyExchange(), MLKEM768KeyExchange.ENCAPSULATION_KEY_LENGTH,
                 MLKEM768KeyExchange.CIPHERTEXT_LENGTH, false);
     }

--- a/src/main/java/tech/kwik/agent15/engine/impl/SecP384r1MLKEM1024KeyExchange.java
+++ b/src/main/java/tech/kwik/agent15/engine/impl/SecP384r1MLKEM1024KeyExchange.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2026 Peter Doornbosch, Chris Burdess
+ *
+ * This file is part of Agent15, an implementation of TLS 1.3 in Java.
+ *
+ * Agent15 is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Agent15 is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package tech.kwik.agent15.engine.impl;
+
+import tech.kwik.agent15.engine.HybridKeyExchange;
+import tech.kwik.agent15.engine.MLKEM1024KeyExchange;
+
+import static tech.kwik.agent15.TlsConstants.NamedGroup.secp384r1;
+
+/**
+ * The SecP384r1MLKEM1024 hybrid group (RFC 10024): classical (EC) component
+ * first in the client/server key shares and the secret combiner.
+ */
+public class SecP384r1MLKEM1024KeyExchange extends HybridKeyExchange {
+
+    public SecP384r1MLKEM1024KeyExchange() {
+        super("SecP384r1MLKEM1024", new ECKeyExchange(secp384r1), 97,
+                new MLKEM1024KeyExchange(), MLKEM1024KeyExchange.ENCAPSULATION_KEY_LENGTH,
+                MLKEM1024KeyExchange.CIPHERTEXT_LENGTH, false);
+    }
+}

--- a/src/main/java/tech/kwik/agent15/engine/impl/SecP384r1MLKEM1024KeyExchange.java
+++ b/src/main/java/tech/kwik/agent15/engine/impl/SecP384r1MLKEM1024KeyExchange.java
@@ -29,8 +29,13 @@ import static tech.kwik.agent15.TlsConstants.NamedGroup.secp384r1;
  */
 public class SecP384r1MLKEM1024KeyExchange extends HybridKeyExchange {
 
+    // RFC 8446 section 4.2.8.2 -- matches ECKeyExchange's own (private)
+    // CURVE_KEY_LENGTHS entry for secp384r1 (uncompressed point: 1 +
+    // 2 * 48-byte coordinates).
+    public static final int SECP384R1_SHARE_LENGTH = 97;
+
     public SecP384r1MLKEM1024KeyExchange() {
-        super("SecP384r1MLKEM1024", new ECKeyExchange(secp384r1), 97,
+        super("SecP384r1MLKEM1024", new ECKeyExchange(secp384r1), SECP384R1_SHARE_LENGTH,
                 new MLKEM1024KeyExchange(), MLKEM1024KeyExchange.ENCAPSULATION_KEY_LENGTH,
                 MLKEM1024KeyExchange.CIPHERTEXT_LENGTH, false);
     }

--- a/src/main/java/tech/kwik/agent15/engine/impl/X25519MLKEM768KeyExchange.java
+++ b/src/main/java/tech/kwik/agent15/engine/impl/X25519MLKEM768KeyExchange.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2026 Peter Doornbosch, Chris Burdess
+ *
+ * This file is part of Agent15, an implementation of TLS 1.3 in Java.
+ *
+ * Agent15 is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Agent15 is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package tech.kwik.agent15.engine.impl;
+
+import tech.kwik.agent15.engine.HybridKeyExchange;
+import tech.kwik.agent15.engine.MLKEM768KeyExchange;
+
+import static tech.kwik.agent15.TlsConstants.NamedGroup.x25519;
+
+/**
+ * The X25519MLKEM768 hybrid group (RFC 10024): ML-KEM component first in
+ * the client/server key shares and the secret combiner.
+ */
+public class X25519MLKEM768KeyExchange extends HybridKeyExchange {
+
+    public X25519MLKEM768KeyExchange() {
+        super("X25519MLKEM768", new XDHKeyExchange(x25519), 32,
+                new MLKEM768KeyExchange(), MLKEM768KeyExchange.ENCAPSULATION_KEY_LENGTH,
+                MLKEM768KeyExchange.CIPHERTEXT_LENGTH, true);
+    }
+}

--- a/src/main/java/tech/kwik/agent15/engine/impl/X25519MLKEM768KeyExchange.java
+++ b/src/main/java/tech/kwik/agent15/engine/impl/X25519MLKEM768KeyExchange.java
@@ -29,8 +29,12 @@ import static tech.kwik.agent15.TlsConstants.NamedGroup.x25519;
  */
 public class X25519MLKEM768KeyExchange extends HybridKeyExchange {
 
+    // RFC 8446 section 4.2.8.2 -- matches XDHKeyExchange's own
+    // (private) CURVE_KEY_LENGTHS entry for x25519.
+    public static final int X25519_SHARE_LENGTH = 32;
+
     public X25519MLKEM768KeyExchange() {
-        super("X25519MLKEM768", new XDHKeyExchange(x25519), 32,
+        super("X25519MLKEM768", new XDHKeyExchange(x25519), X25519_SHARE_LENGTH,
                 new MLKEM768KeyExchange(), MLKEM768KeyExchange.ENCAPSULATION_KEY_LENGTH,
                 MLKEM768KeyExchange.CIPHERTEXT_LENGTH, true);
     }

--- a/src/test/java/tech/kwik/agent15/engine/impl/KeyExchangeFactoryImplTest.java
+++ b/src/test/java/tech/kwik/agent15/engine/impl/KeyExchangeFactoryImplTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2026 Peter Doornbosch, Chris Burdess
+ *
+ * This file is part of Agent15, an implementation of TLS 1.3 in Java.
+ *
+ * Agent15 is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Agent15 is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package tech.kwik.agent15.engine.impl;
+
+import org.junit.jupiter.api.Test;
+import tech.kwik.agent15.engine.KeyExchange;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.kwik.agent15.TlsConstants.NamedGroup.*;
+
+class KeyExchangeFactoryImplTest {
+
+    @Test
+    void forGroupReturnsTheHybridImplementationsForTheRfc10024Groups() {
+        KeyExchangeFactoryImpl factory = new KeyExchangeFactoryImpl();
+
+        assertThat(factory.forGroup(X25519MLKEM768)).isInstanceOf(X25519MLKEM768KeyExchange.class);
+        assertThat(factory.forGroup(SecP256r1MLKEM768)).isInstanceOf(SecP256r1MLKEM768KeyExchange.class);
+        assertThat(factory.forGroup(SecP384r1MLKEM1024)).isInstanceOf(SecP384r1MLKEM1024KeyExchange.class);
+    }
+
+    @Test
+    void forGroupStillReturnsTheClassicalImplementationsForClassicalGroups() {
+        KeyExchangeFactoryImpl factory = new KeyExchangeFactoryImpl();
+
+        assertThat(factory.forGroup(x25519)).isInstanceOf(XDHKeyExchange.class);
+        assertThat(factory.forGroup(x448)).isInstanceOf(XDHKeyExchange.class);
+        assertThat(factory.forGroup(secp256r1)).isInstanceOf(ECKeyExchange.class);
+        assertThat(factory.forGroup(secp384r1)).isInstanceOf(ECKeyExchange.class);
+        assertThat(factory.forGroup(secp521r1)).isInstanceOf(ECKeyExchange.class);
+    }
+
+    @Test
+    void initDoesNotThrowAndForGroupStillWorksAfterwards() {
+        KeyExchangeFactoryImpl factory = new KeyExchangeFactoryImpl();
+
+        factory.init();
+
+        KeyExchange keyExchange = factory.forGroup(X25519MLKEM768);
+        assertThat(keyExchange).isInstanceOf(X25519MLKEM768KeyExchange.class);
+        keyExchange.generateClientKeyPair();
+        assertThat(keyExchange.getClientKeyShare()).isNotEmpty();
+    }
+}

--- a/src/test/java/tech/kwik/agent15/engine/impl/SecP256r1MLKEM768KeyExchangeTest.java
+++ b/src/test/java/tech/kwik/agent15/engine/impl/SecP256r1MLKEM768KeyExchangeTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2026 Peter Doornbosch, Chris Burdess
+ *
+ * This file is part of Agent15, an implementation of TLS 1.3 in Java.
+ *
+ * Agent15 is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Agent15 is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package tech.kwik.agent15.engine.impl;
+
+import org.junit.jupiter.api.Test;
+import tech.kwik.agent15.engine.MLKEM768KeyExchange;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SecP256r1MLKEM768KeyExchangeTest {
+
+    @Test
+    void clientAndServerDeriveTheSameSharedSecretWithRealComponents() throws Exception {
+        SecP256r1MLKEM768KeyExchange client = new SecP256r1MLKEM768KeyExchange();
+        client.generateClientKeyPair();
+        byte[] clientKeyShare = client.getClientKeyShare();
+        assertThat(clientKeyShare).hasSize(65 + MLKEM768KeyExchange.ENCAPSULATION_KEY_LENGTH);
+
+        SecP256r1MLKEM768KeyExchange server = new SecP256r1MLKEM768KeyExchange();
+        byte[] serverSecret = server.serverProcessClientKeyShare(clientKeyShare);
+        byte[] serverKeyShare = server.getServerKeyShare();
+        assertThat(serverKeyShare).hasSize(65 + MLKEM768KeyExchange.CIPHERTEXT_LENGTH);
+
+        byte[] clientSecret = client.clientComputeSharedSecret(serverKeyShare);
+        assertThat(clientSecret).isEqualTo(serverSecret);
+    }
+}

--- a/src/test/java/tech/kwik/agent15/engine/impl/SecP256r1MLKEM768KeyExchangeTest.java
+++ b/src/test/java/tech/kwik/agent15/engine/impl/SecP256r1MLKEM768KeyExchangeTest.java
@@ -30,12 +30,12 @@ class SecP256r1MLKEM768KeyExchangeTest {
         SecP256r1MLKEM768KeyExchange client = new SecP256r1MLKEM768KeyExchange();
         client.generateClientKeyPair();
         byte[] clientKeyShare = client.getClientKeyShare();
-        assertThat(clientKeyShare).hasSize(65 + MLKEM768KeyExchange.ENCAPSULATION_KEY_LENGTH);
+        assertThat(clientKeyShare).hasSize(SecP256r1MLKEM768KeyExchange.SECP256R1_SHARE_LENGTH + MLKEM768KeyExchange.ENCAPSULATION_KEY_LENGTH);
 
         SecP256r1MLKEM768KeyExchange server = new SecP256r1MLKEM768KeyExchange();
         byte[] serverSecret = server.serverProcessClientKeyShare(clientKeyShare);
         byte[] serverKeyShare = server.getServerKeyShare();
-        assertThat(serverKeyShare).hasSize(65 + MLKEM768KeyExchange.CIPHERTEXT_LENGTH);
+        assertThat(serverKeyShare).hasSize(SecP256r1MLKEM768KeyExchange.SECP256R1_SHARE_LENGTH + MLKEM768KeyExchange.CIPHERTEXT_LENGTH);
 
         byte[] clientSecret = client.clientComputeSharedSecret(serverKeyShare);
         assertThat(clientSecret).isEqualTo(serverSecret);

--- a/src/test/java/tech/kwik/agent15/engine/impl/SecP384r1MLKEM1024KeyExchangeTest.java
+++ b/src/test/java/tech/kwik/agent15/engine/impl/SecP384r1MLKEM1024KeyExchangeTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2026 Peter Doornbosch, Chris Burdess
+ *
+ * This file is part of Agent15, an implementation of TLS 1.3 in Java.
+ *
+ * Agent15 is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Agent15 is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package tech.kwik.agent15.engine.impl;
+
+import org.junit.jupiter.api.Test;
+import tech.kwik.agent15.engine.MLKEM1024KeyExchange;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SecP384r1MLKEM1024KeyExchangeTest {
+
+    @Test
+    void clientAndServerDeriveTheSameSharedSecretWithRealComponents() throws Exception {
+        SecP384r1MLKEM1024KeyExchange client = new SecP384r1MLKEM1024KeyExchange();
+        client.generateClientKeyPair();
+        byte[] clientKeyShare = client.getClientKeyShare();
+        assertThat(clientKeyShare).hasSize(97 + MLKEM1024KeyExchange.ENCAPSULATION_KEY_LENGTH);
+
+        SecP384r1MLKEM1024KeyExchange server = new SecP384r1MLKEM1024KeyExchange();
+        byte[] serverSecret = server.serverProcessClientKeyShare(clientKeyShare);
+        byte[] serverKeyShare = server.getServerKeyShare();
+        assertThat(serverKeyShare).hasSize(97 + MLKEM1024KeyExchange.CIPHERTEXT_LENGTH);
+
+        byte[] clientSecret = client.clientComputeSharedSecret(serverKeyShare);
+        assertThat(clientSecret).isEqualTo(serverSecret);
+    }
+}

--- a/src/test/java/tech/kwik/agent15/engine/impl/SecP384r1MLKEM1024KeyExchangeTest.java
+++ b/src/test/java/tech/kwik/agent15/engine/impl/SecP384r1MLKEM1024KeyExchangeTest.java
@@ -30,12 +30,12 @@ class SecP384r1MLKEM1024KeyExchangeTest {
         SecP384r1MLKEM1024KeyExchange client = new SecP384r1MLKEM1024KeyExchange();
         client.generateClientKeyPair();
         byte[] clientKeyShare = client.getClientKeyShare();
-        assertThat(clientKeyShare).hasSize(97 + MLKEM1024KeyExchange.ENCAPSULATION_KEY_LENGTH);
+        assertThat(clientKeyShare).hasSize(SecP384r1MLKEM1024KeyExchange.SECP384R1_SHARE_LENGTH + MLKEM1024KeyExchange.ENCAPSULATION_KEY_LENGTH);
 
         SecP384r1MLKEM1024KeyExchange server = new SecP384r1MLKEM1024KeyExchange();
         byte[] serverSecret = server.serverProcessClientKeyShare(clientKeyShare);
         byte[] serverKeyShare = server.getServerKeyShare();
-        assertThat(serverKeyShare).hasSize(97 + MLKEM1024KeyExchange.CIPHERTEXT_LENGTH);
+        assertThat(serverKeyShare).hasSize(SecP384r1MLKEM1024KeyExchange.SECP384R1_SHARE_LENGTH + MLKEM1024KeyExchange.CIPHERTEXT_LENGTH);
 
         byte[] clientSecret = client.clientComputeSharedSecret(serverKeyShare);
         assertThat(clientSecret).isEqualTo(serverSecret);

--- a/src/test/java/tech/kwik/agent15/engine/impl/X25519MLKEM768KeyExchangeTest.java
+++ b/src/test/java/tech/kwik/agent15/engine/impl/X25519MLKEM768KeyExchangeTest.java
@@ -30,12 +30,12 @@ class X25519MLKEM768KeyExchangeTest {
         X25519MLKEM768KeyExchange client = new X25519MLKEM768KeyExchange();
         client.generateClientKeyPair();
         byte[] clientKeyShare = client.getClientKeyShare();
-        assertThat(clientKeyShare).hasSize(32 + MLKEM768KeyExchange.ENCAPSULATION_KEY_LENGTH);
+        assertThat(clientKeyShare).hasSize(X25519MLKEM768KeyExchange.X25519_SHARE_LENGTH + MLKEM768KeyExchange.ENCAPSULATION_KEY_LENGTH);
 
         X25519MLKEM768KeyExchange server = new X25519MLKEM768KeyExchange();
         byte[] serverSecret = server.serverProcessClientKeyShare(clientKeyShare);
         byte[] serverKeyShare = server.getServerKeyShare();
-        assertThat(serverKeyShare).hasSize(32 + MLKEM768KeyExchange.CIPHERTEXT_LENGTH);
+        assertThat(serverKeyShare).hasSize(X25519MLKEM768KeyExchange.X25519_SHARE_LENGTH + MLKEM768KeyExchange.CIPHERTEXT_LENGTH);
 
         byte[] clientSecret = client.clientComputeSharedSecret(serverKeyShare);
         assertThat(clientSecret).isEqualTo(serverSecret);

--- a/src/test/java/tech/kwik/agent15/engine/impl/X25519MLKEM768KeyExchangeTest.java
+++ b/src/test/java/tech/kwik/agent15/engine/impl/X25519MLKEM768KeyExchangeTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2026 Peter Doornbosch, Chris Burdess
+ *
+ * This file is part of Agent15, an implementation of TLS 1.3 in Java.
+ *
+ * Agent15 is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Agent15 is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package tech.kwik.agent15.engine.impl;
+
+import org.junit.jupiter.api.Test;
+import tech.kwik.agent15.engine.MLKEM768KeyExchange;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class X25519MLKEM768KeyExchangeTest {
+
+    @Test
+    void clientAndServerDeriveTheSameSharedSecretWithRealComponents() throws Exception {
+        X25519MLKEM768KeyExchange client = new X25519MLKEM768KeyExchange();
+        client.generateClientKeyPair();
+        byte[] clientKeyShare = client.getClientKeyShare();
+        assertThat(clientKeyShare).hasSize(32 + MLKEM768KeyExchange.ENCAPSULATION_KEY_LENGTH);
+
+        X25519MLKEM768KeyExchange server = new X25519MLKEM768KeyExchange();
+        byte[] serverSecret = server.serverProcessClientKeyShare(clientKeyShare);
+        byte[] serverKeyShare = server.getServerKeyShare();
+        assertThat(serverKeyShare).hasSize(32 + MLKEM768KeyExchange.CIPHERTEXT_LENGTH);
+
+        byte[] clientSecret = client.clientComputeSharedSecret(serverKeyShare);
+        assertThat(clientSecret).isEqualTo(serverSecret);
+    }
+}


### PR DESCRIPTION
Building on secp384r1/521r1 support and the alert-type fix, thanks for
turning those around so fast.

Included:
- X25519MLKEM768KeyExchange, SecP256r1MLKEM768KeyExchange,
  SecP384r1MLKEM1024KeyExchange, each a thin HybridKeyExchange
  subclass wiring the right XDHKeyExchange/ECKeyExchange to the right
  MLKEM768KeyExchange/MLKEM1024KeyExchange, per RFC 10024 section 7's
  lengths and ordering.
- KeyExchangeFactoryImpl.forGroup() now routes all three hybrid groups
  alongside the existing classical ones.
- KeyExchangeFactoryImpl.init() now actually does something: touches
  both MLKEM classes so their DER-prefix static-init cost lands during
  an explicit warm-up call rather than on a live handshake. Nothing
  calls init() in the engine itself, it's meant to be an
  embedding-application hook.
- Tests for all three groups against your real ECKeyExchange/
  XDHKeyExchange.
